### PR TITLE
update html to include gradient overlay on banner images

### DIFF
--- a/src/app/communities/communities.component.html
+++ b/src/app/communities/communities.component.html
@@ -13,11 +13,13 @@
             <md-card class="pretty-card" *ngFor="let community of communities | async" [routerLink]="['/communities/',community.$key]">
                 <li>
                     <div class="card-hero-wrapper">
-                        <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))" [style.background-image]="'url('+(community.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+                        <div class="card-hero" [style.background-image]="'url('+(community.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+                          <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))">
                             <div class="card-hero__content">
                                 <md-card-title>{{community.icon}} {{community.name}}</md-card-title>
                                 <md-card-subtitle>{{community.location}}</md-card-subtitle>
                             </div>
+                          </div>
                         </div>
                     </div>
 

--- a/src/app/communities/community-view.component.html
+++ b/src/app/communities/community-view.component.html
@@ -6,11 +6,13 @@
   <main class="main-content internal-view">
     <md-card class="profile-card">
       <div class="card-hero-wrapper view-page">
-        <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8)), url('')">
-          <div class="card-hero__content">
-            <h2>{{community.icon}} {{community.name}}</h2>
-            <br>
-            <a class="join" [href]="community.url">Join</a>
+        <div class="card-hero" [style.background-image]="'url('+(community.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+          <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))">
+            <div class="card-hero__content">
+              <h2>{{community.icon}} {{community.name}}</h2>
+              <br>
+              <a class="join" [href]="community.url">Join</a>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/events/event-view.component.html
+++ b/src/app/events/event-view.component.html
@@ -6,13 +6,15 @@
   <main class="main-content internal-view">
     <md-card class="profile-card">
       <div class="card-hero-wrapper view-page">
-        <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8)), url('')">
-          <div class="card-hero__content">
-            <img [src]="event.logoUrl" class="event-logo">
-            <br>
-            <h2>{{ event.name }}</h2>
-            <br>
-            <a class="join">Join</a>
+        <div class="card-hero" [style.background-image]="'url('+(event.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+          <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))">
+            <div class="card-hero__content">
+              <img [src]="event.logoUrl" class="event-logo">
+              <br>
+              <h2>{{ event.name }}</h2>
+              <br>
+              <a class="join">Join</a>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/events/events.component.html
+++ b/src/app/events/events.component.html
@@ -15,11 +15,13 @@
         <li>
 
           <div class="card-hero-wrapper">
-            <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8)), url('')">
-              <div class="card-hero__content">
-                <div [style.background-image]="'url('+event.logoUrl+')'" *ngIf="event.logoUrl" class="background-side-picture contain"></div>
-                <md-card-title>{{event.name}}</md-card-title>
-                <md-card-subtitle>{{event.location}}</md-card-subtitle>
+            <div class="card-hero" [style.background-image]="'url('+(event.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+              <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))">
+                <div class="card-hero__content">
+                  <div [style.background-image]="'url('+event.logoUrl+')'" *ngIf="event.logoUrl" class="background-side-picture contain"></div>
+                  <md-card-title>{{event.name}}</md-card-title>
+                  <md-card-subtitle>{{event.location}}</md-card-subtitle>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/missions/mission-detail.component.html
+++ b/src/app/missions/mission-detail.component.html
@@ -6,11 +6,13 @@
   <main class="main-content internal-view">
     <md-card class="profile-card">
       <div class="card-hero-wrapper view-page">
-        <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8)), url('')">
-          <div class="card-hero__content">
-            <h2>{{ mission.name}}</h2>
-            <br>
-            <a class="join">Join</a>
+        <div class="card-hero" [style.background-image]="'url('+(mission.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+          <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))">
+            <div class="card-hero__content">
+              <h2>{{ mission.name}}</h2>
+              <br>
+              <a class="join">Join</a>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/missions/mission-list.component.html
+++ b/src/app/missions/mission-list.component.html
@@ -1,5 +1,5 @@
 <header class="hero-background">
-  <h2 class="internal-header">Mission List</h2>
+  <h2 class="internal-header">Missions</h2>
 </header>
 
 <main class="main-content">
@@ -23,9 +23,11 @@
         <li>
 
           <div class="card-hero-wrapper">
-            <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8)), url('')">
-              <div class="card-hero__content">
-                <md-card-title>{{mission.name}}</md-card-title>
+            <div class="card-hero" [style.background-image]="'url('+(mission.bannerUrl?community.bannerUrl:'/assets/images/card-placeholder.jpg')+')'">
+              <div class="card-hero" style="background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.8))">
+                <div class="card-hero__content">
+                  <md-card-title>{{mission.name}}</md-card-title>
+                </div>
               </div>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,8 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
 </head>
 <body>
   <app-root>Loading...</app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -335,6 +335,7 @@ $nav-link-color: #fff;
   display: flex;
   height: 130px;
   overflow: hidden;
+  width: 100%;
 }
 
 .events-component .card-hero {


### PR DESCRIPTION
### Changes
* Add gradient overlay on top of banner images in community, events and missions
* Add material icons font to index 

### Preview 
Gradient Overlay Example
<img width="229" src="https://cloud.githubusercontent.com/assets/10601477/18537258/52f86b96-7ad2-11e6-8ce3-cfb694bed48f.png">

Icon Example
<img width="420" src="https://cloud.githubusercontent.com/assets/10601477/18537270/68074ae8-7ad2-11e6-92e7-1d57d1df16cf.png">

