### PR TITLE
Fixing warning when using the ng cli

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -1,6 +1,6 @@
 {
   "project": {
-    "version": "1.0.0-beta.21",
+    "version": "1.0.0-rc.0",
     "name": "master-proj"
   },
   "apps": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "4.0.0-rc.1",
-    "@angular/cli": "1.0.0-rc.0",
     "@angular/common": "4.0.0-rc.1",
     "@angular/compiler": "4.0.0-rc.1",
     "@angular/compiler-cli": "4.0.0-rc.1",
@@ -36,6 +35,7 @@
     "zone.js": "^0.7.4"
   },
   "devDependencies": {
+    "@angular/cli": "1.0.0-rc.0",
     "@types/jasmine": "^2.2.30",
     "codelyzer": "~0.0.26",
     "jasmine-core": "2.4.1",


### PR DESCRIPTION
Whenever you use `npm start` there's a warning about the version of the cli because of this issue: https://github.com/angular/angular-cli/issues/5112
This PR fixes the problem for this project.